### PR TITLE
在Outlook中显示日程为Free

### DIFF
--- a/lunar_ical.py
+++ b/lunar_ical.py
@@ -44,6 +44,7 @@ ICAL_HEAD = ('BEGIN:VCALENDAR\n'
              'X-WR-CALDESC:中国农历1901-2100, 包括节气. 数据来自香港天文台')
 
 ICAL_SEC = ('BEGIN:VEVENT\n'
+            'X-MICROSOFT-CDO-BUSYSTATUS:FREE\n'
             'DTSTAMP:%s\n'
             'UID:%s\n'
             'DTSTART;VALUE=DATE:%s\n'


### PR DESCRIPTION
当前的日程在导入Outlook中后会显示为Busy
加入X-MICROSOFT-CDO-BUSYSTATUS:FREE后能让其恢复Free状态。